### PR TITLE
Support browser polyfill API

### DIFF
--- a/src/createStorage.js
+++ b/src/createStorage.js
@@ -10,7 +10,7 @@ export default function createStorage(type: 'local' | 'sync') {
             .then((value) => {
               resolve(value[key]);
             })
-            .catch((e) => reject(e));
+            .catch(reject);
         } else {
           chrome.storage[type].get(key, (value) => {
             if (chrome.runtime.lastError == null) {
@@ -30,7 +30,7 @@ export default function createStorage(type: 'local' | 'sync') {
           browser.storage[type]
             .remove(key)
             .then(resolve)
-            .catch((e) => reject(e));
+            .catch(reject);
         } else {
           chrome.storage[type].remove(key, () => {
             if (chrome.runtime.lastError == null) {
@@ -48,7 +48,7 @@ export default function createStorage(type: 'local' | 'sync') {
           browser.storage[type]
             .set({ [key]: value })
             .then(resolve)
-            .catch((e) => reject(e));
+            .catch(reject);
         } else {
           chrome.storage[type].set({ [key]: value }, () => {
             if (chrome.runtime.lastError == null) {

--- a/src/createStorage.js
+++ b/src/createStorage.js
@@ -4,7 +4,14 @@ export default function createStorage(type: 'local' | 'sync') {
   return {
     getItem(key: string) {
       return new Promise((resolve, reject) => {
-        if (typeof chrome !== 'undefined') {
+        if (typeof browser !== 'undefined') {
+          browser.storage[type]
+            .get(key)
+            .then((value) => {
+              resolve(value[key]);
+            })
+            .catch((e) => reject(e));
+        } else {
           chrome.storage[type].get(key, (value) => {
             if (chrome.runtime.lastError == null) {
               // Chrome Storage returns the value in an Object of with its original key. Unwrap the
@@ -14,19 +21,17 @@ export default function createStorage(type: 'local' | 'sync') {
               reject();
             }
           });
-        } else {
-          browser.storage[type]
-            .get(key)
-            .then((value) => {
-              resolve(value[key]);
-            })
-            .catch((e) => reject(e));
         }
       });
     },
     removeItem(key: string) {
       return new Promise((resolve, reject) => {
-        if (typeof chrome !== 'undefined') {
+        if (typeof browser !== 'undefined') {
+          browser.storage[type]
+            .remove(key)
+            .then(resolve)
+            .catch((e) => reject(e));
+        } else {
           chrome.storage[type].remove(key, () => {
             if (chrome.runtime.lastError == null) {
               resolve();
@@ -34,17 +39,17 @@ export default function createStorage(type: 'local' | 'sync') {
               reject();
             }
           });
-        } else {
-          browser.storage[type]
-            .remove(key)
-            .then(resolve)
-            .catch((e) => reject(e));
         }
       });
     },
     setItem(key: string, value: mixed) {
       return new Promise((resolve, reject) => {
-        if (typeof chrome !== 'undefined') {
+        if (typeof browser !== 'undefined') {
+          browser.storage[type]
+            .set({ [key]: value })
+            .then(resolve)
+            .catch((e) => reject(e));
+        } else {
           chrome.storage[type].set({ [key]: value }, () => {
             if (chrome.runtime.lastError == null) {
               resolve();
@@ -52,11 +57,6 @@ export default function createStorage(type: 'local' | 'sync') {
               reject();
             }
           });
-        } else {
-          browser.storage[type]
-            .set({ [key]: value })
-            .then(resolve)
-            .catch((e) => reject(e));
         }
       });
     },

--- a/src/createStorage.js
+++ b/src/createStorage.js
@@ -4,37 +4,60 @@ export default function createStorage(type: 'local' | 'sync') {
   return {
     getItem(key: string) {
       return new Promise((resolve, reject) => {
-        chrome.storage[type].get(key, value => {
-          if (chrome.runtime.lastError == null) {
-            // Chrome Storage returns the value in an Object of with its original key. Unwrap the
-            // value from the returned Object to match the `getItem` API.
-            resolve(value[key]);
-          } else {
-            reject();
-          }
-        });
+        if (typeof chrome !== 'undefined') {
+          chrome.storage[type].get(key, (value) => {
+            if (chrome.runtime.lastError == null) {
+              // Chrome Storage returns the value in an Object of with its original key. Unwrap the
+              // value from the returned Object to match the `getItem` API.
+              resolve(value[key]);
+            } else {
+              reject();
+            }
+          });
+        } else {
+          browser.storage[type]
+            .get(key)
+            .then((value) => {
+              resolve(value[key]);
+            })
+            .catch((e) => reject(e));
+        }
       });
     },
     removeItem(key: string) {
       return new Promise((resolve, reject) => {
-        chrome.storage[type].remove(key, () => {
-          if (chrome.runtime.lastError == null) {
-            resolve();
-          } else {
-            reject();
-          }
-        });
+        if (typeof chrome !== 'undefined') {
+          chrome.storage[type].remove(key, () => {
+            if (chrome.runtime.lastError == null) {
+              resolve();
+            } else {
+              reject();
+            }
+          });
+        } else {
+          browser.storage[type]
+            .remove(key)
+            .then(resolve)
+            .catch((e) => reject(e));
+        }
       });
     },
     setItem(key: string, value: mixed) {
       return new Promise((resolve, reject) => {
-        chrome.storage[type].set({ [key]: value }, () => {
-          if (chrome.runtime.lastError == null) {
-            resolve();
-          } else {
-            reject();
-          }
-        });
+        if (typeof chrome !== 'undefined') {
+          chrome.storage[type].set({ [key]: value }, () => {
+            if (chrome.runtime.lastError == null) {
+              resolve();
+            } else {
+              reject();
+            }
+          });
+        } else {
+          browser.storage[type]
+            .set({ [key]: value })
+            .then(resolve)
+            .catch((e) => reject(e));
+        }
       });
     },
   };


### PR DESCRIPTION
This pull request adds fallback support, in case the browser does not have the `chrome` namespace defined.

Solves #1 